### PR TITLE
fix: 处理files中file为空的情况

### DIFF
--- a/src/depsAnalyzer/utils/genData.js
+++ b/src/depsAnalyzer/utils/genData.js
@@ -38,6 +38,7 @@ const genPageData = ({
   let totalSize = 0
   const files = pageDeps.files.sort()
   files.forEach(file => {
+    if (!file) return
     const fileData = genFileData(file, allFileInfo)
     children.push(fileData)
     totalSize += fileData.size


### PR DESCRIPTION
某些情况下可以不写json文件，比如只做跳转，这是分析size过程会报错，因为收集到的files中有一项为空，需要兼容